### PR TITLE
Sdsidebandsplit fix bibliography

### DIFF
--- a/docs/tasks/task_sdsidebandsplit.rst
+++ b/docs/tasks/task_sdsidebandsplit.rst
@@ -225,7 +225,8 @@ Description
    *threshold*.
    
    
-   Bibliography
+   .. rubric:: Bibliography
+
    :sup:`1. Emerson, Klein, & Haslam 1979, A&A, 76, 92
    (` `ADS <http://adsabs.harvard.edu/abs/1979A%26A....76...92E>`__ :sup:`)` `<#ref-cit1>`__
    

--- a/docs/tasks/task_sdsidebandsplit.rst
+++ b/docs/tasks/task_sdsidebandsplit.rst
@@ -14,7 +14,7 @@ Description
    by utilizing the feature that spectral lines in the two sidebands
    shift in different amounts between observations with different LO
    offsets. The algorithm used in the task is analogous to that of
-   Emerson, Klein, & Haslam (1979) `[1] <#cit1>`__ with shifts in the
+   Emerson, Klein, & Haslam (1979) :ref:`[1] <cit1>` with shifts in the
    frequency domain instead of spatial one as described in the paper.
    The details of algorithm is also discussed in the section, `Brief
    description of the mathematics behind the
@@ -227,8 +227,10 @@ Description
 
    .. rubric:: Bibliography
 
-   :sup:`1. Emerson, Klein, & Haslam 1979, A&A, 76, 92
-   (` `ADS <http://adsabs.harvard.edu/abs/1979A%26A....76...92E>`__ :sup:`)` `<#ref-cit1>`__
+   .. _cit1:
+
+   `1. Emerson, Klein, & Haslam 1979, A&A, 76, 92
+   (` `ADS <http://adsabs.harvard.edu/abs/1979A%26A....76...92E>`__ `)`
 
 
 .. _Examples:

--- a/docs/tasks/task_sdsidebandsplit.rst
+++ b/docs/tasks/task_sdsidebandsplit.rst
@@ -7,7 +7,7 @@ Description
 
    .. warning:: **WARNING**: This task is EXPERIMENTAL. Interface and
       capabilities may change frequently.
-   
+
    The task **sdsidebandsplit** performs a sideband separation
    operation on data collected by double sideband (DSB) receivers.
    The task splits the emission from the signal and image sidebands
@@ -20,7 +20,7 @@ Description
    description of the mathematics behind the
    task <#brief-description-of-the-mathematics-behind-the-task>`__,
    below.
-   
+
    The task takes two or more images as inputs and is able to
    identify and split the contribution from the signal and image
    sidebands. The resulting output are separate image(s). When the
@@ -46,10 +46,10 @@ Description
    *signalshift* and *imageshift*. The default frequency parameters
    in **sdimaging** (*nchan=-1*, *start=0*, and *width=1*) help to
    avoid in adding this complexity.
-   
+
    .. rubric:: Definition of *signalshift* and *imageshift*
-      
-   
+
+
    Since the input images do not have information on how much the
    frequency is offset in the spectral window in each observation,
    **sdsidebandsplit** relies on user to provide it. Currently, the
@@ -61,7 +61,7 @@ Description
    number of elements in signalshift must be equal to that of
    imagename.  The parameter *imageshift* is the same as
    *signalshift* but for the image sideband.
-   
+
    .. note:: *signalshift* and *imageshift* must be defined in the
       unit of channel numbers in the image. The **sdsidebandsplit**
       task relies on these values to shift back the spectra and
@@ -72,10 +72,10 @@ Description
       shifts especially in case the frequency coordinate of input
       images is different from the native observation, for example by
       regridding and/or by converting frequency frame.
-   
+
    .. rubric:: Solution flag: *otherside*
-      
-   
+
+
    There are two ways to obtain a spectrum of a sideband of interest
    in **sdsidebandsplit**. The parameter *otherside* allows a user to
    switch between the image or signal sideband. When solving for the
@@ -87,7 +87,7 @@ Description
    by solving that of the other, image (signal), sideband and by
    subtracting it from the observed spectrum which contains
    contribution from both sidebands.
-   
+
    Setting *otherside=True* may have an advantage of removing
    residual offsets in a spectrum. This is because the current
    algorithm does not take into account the sideband ratio and the
@@ -104,10 +104,10 @@ Description
    When this ghost emission in addition to the offset component is
    subtracted from the original spectrum (*otherside=True*), it may
    cause a negative offset in the derived spectrum.
-   
+
    .. rubric:: Frequency definition of image sideband
-      
-   
+
+
    Since the input images do not have information of the frequency
    settings of the output image of the image sideband,
    **sdsidebandsplit** relies on user inputs when solving for the
@@ -119,15 +119,15 @@ Description
    increment of the signal sideband is 4880kHz, that of image
    sideband is defined as -4880kHz. See the Examples tab for a sample
    use case showing how to specify *refpix* and *refval*.
-   
-    
-   
+
+
+
    .. rubric:: Brief description of the mathematics behind the task
-      
-   
+
+
    The algorithm to split signals from two sidebands is based on the
    following criteria:
-   
+
    -  The sign of the frequency increment for the image sideband is
       opposite to that for the signal sideband (Note that “signal
       sideband” and “image sideband” are the nominal terms that
@@ -144,69 +144,69 @@ Description
       represented as a modulation, which is a multiplication of a
       sinusoidal wave whose frequency is equal to the amount of the
       frequency shift.
-   
+
    Suppose that :math:`h` is an output spectrum of DSB system and
    :math:`f`, :math:`g` represent contributions from signal and image
-   sidebands, respectively. Then, 
-   
+   sidebands, respectively. Then,
+
    :math:`h_{m k} = f_{m k} + g_{m k}`, :math:`k=0,1,2,...,N-1`,
-   
+
    where :math:`k` denotes channel index and :math:`N` is a number
    of spectral channels. If LO frequency shift by x causes
    :math:`f_{m k}` and :math:`g_{m k}` to shift by
    :math:`\Delta^{m x}_{m f}` and :math:`\Delta^{m x}_{m g}`
    with respect to its original spectra, respectively, output
    spectrum with shift is wrtten as,
-   
+
    :math:`h^{m x}_{m k} = f_{m k - \Delta^x_f} + g_{m k - \Delta^x_g}`.
-   
+
    We can shift :math:`h^{m x}_{m k}` as if the contribution from
    image sideband, :math:`g`, is being unshifted. By
    shifting :math:`h^{m x}_{m k}`
    by :math:`-\Delta^{m x}_{m g}`, we can construct such
    spectrum,
-   
+
    :math:`h^{m x,imag}_{m k} = f_{m k - \Delta^x} + g_{m k}`,
-   
+
    where
    :math:`\Delta^{m x} = \Delta^{m x}_{m f} - \Delta^{m x}_{m g}`.
    Channel shift in the signal sideband is represented as a
    modulation in Fourier (time) domain. Thus, Fourier transform of
    the above is written as,
-   
+
    :math:`H^{m x,imag}_{m t} = F_{m t} \exp(-i \frac{2\pi t \Delta^{m x}}{N}) + G_{m t}`,
-   
+
    where :math:`H^{m x,imag}_{m t}`, :math:`F_{m t}`, and
    :math:`G_{m t}` are Fourier transform
    of :math:`h^{m x,imag}_{m k}`, :math:`f_{m k}`, and
    :math:`g_{m k}`, respectively. Applying similar procedure for
    the different LO frequency offset, y, we can obtain another
    result:
-   
+
    :math:`H^{m y,imag}_{m t} = F_{m t} \exp(-i \frac{2\pi t \Delta^{m y}}{N}) + G_{m t}`.
-   
+
    we can obtain :math:`G_{m t}`, Fourier transform of the
    contribution from image sideband, :math:`g_{m k}`, from the
    above two results,
-   
+
    :math:`G_{m t} = \frac{1}{2} (H^{m x,imag}_{m t} + H^{m y,imag}_{m t}) + \frac{1}{2} \frac{\cos\theta}{i\sin\theta} (H^{m x,imag}_{m t} - H^{m y,imag}_{m t})`,
-   
+
    where
    :math:`\theta = 2\pi t (\Delta^{m x} - \Delta^{m y}) / N`.
-   
+
    There are two ways to obtain the contribution from signal
    sideband. One is to solve signal sideband exactly same procedure
    with the above. By doing that, we obtain,
-   
+
    :math:`F_{m t} = \frac{1}{2} (H^{m x,sig}_{m t} + H^{m y,sig}_{m t}) - \frac{1}{2} \frac{\cos\theta}{i\sin\theta} (H^{m x,sig}_{m t} - H^{m y,sig}_{m t})`,
-   
+
    where the quantity with superscript "sig" corresponds to the
    shifted spectrum so that contribution from the signal sideband
    remain fixed. This is what the **sdsidebandsplit** does
    when *otherside=True*. Another way is to subtract the contribution
    of image sideband from the output spectrum. If *otherside=False*,
-   contribution from signal sideband is estimated in that way. 
-   
+   contribution from signal sideband is estimated in that way.
+
    In principle, the task can split contributions from signal and
    image sidebands if only two images with different LO shifts are
    given. However, the task accepts more than two images to obtain
@@ -214,8 +214,8 @@ Description
    based on independent LO shifts, there are :math:`m(m-1)/2`
    combinations to obtain the solution of splitted spectra. In that
    case, the task takes average of those solutions to get a final
-   solution. 
-   
+   solution.
+
    Note that, when :math:`\Delta^{m x}` and :math:`\Delta^{m y}`
    are so close that :math:`\theta` becomes almost zero, the above
    solution could diverge. Such a solution must be avoided to obtain
@@ -223,57 +223,57 @@ Description
    purpose. It should range from 0.0 to 1.0.  The solution will be
    excluded from the process if :math:`|\sin(\theta)|` is less than
    *threshold*.
-   
-   
+
+
    .. rubric:: Bibliography
 
    :sup:`1. Emerson, Klein, & Haslam 1979, A&A, 76, 92
    (` `ADS <http://adsabs.harvard.edu/abs/1979A%26A....76...92E>`__ :sup:`)` `<#ref-cit1>`__
-   
+
 
 .. _Examples:
 
 Examples
    Obtain an image of signal sideband (side band supression):
-   
+
    ::
-   
+
       sdsidebandsplit(imagename=['shift_0ch.image', 'shift_132ch.image',
                       'shift_neg81ch.image'], outfile='separated.image',
                       signalshift=[0.0, +132.0, -81.0],
                       imageshift=[0.0, -132.0, +81.0])
-   
+
    The output image is 'separated.image.signalband'.
 
    To solve both signal and image sidebands, set frequency of image
    sideband explicitly in addtion to *getbothside=True*.
-   
+
    ::
-   
+
       sdsidebandsplit(imagename=['shift_0ch.image', 'shift_132ch.image',
                       'shift_neg81ch.image'], outfile='separated.image',
                       signalshift=[0.0, +132.0, -81.0],
                       imageshift=[0.0, -132.0, +81.0], getbothside=True,
                       refpix=0.0, refval='805.8869GHz')
-   
+
    The output images are 'separated.image.signalband' and
    'separated.image.imageband' for signal and image sideband,
    respectively.
 
    To obtain signal sideband image by solving image sideband, set
    *otherside=True*:
-   
+
    ::
-   
+
       sdsidebandsplit(imagename=['shift_0ch.image', 'shift_132ch.image',
                       'shift_neg81ch.image'], outfile='separated.image',
                       signalshift=[0.0, +132.0, -81.0],
                       imageshift=[0.0, -132.0, +81.0], otherside=True)
-   
+
    Solution of image sideband is obtained and subtracted from the
    original (double sideband) spectra to derive spectra of signal
    sideband. The output image is 'separated.image.signalband'.
-   
+
 
 .. _Development:
 


### PR DESCRIPTION
Fixes style issue in the description of `sdsidebandsplit` task. Bibliography section is updated. Below is the appearances of before and after fix. 

BEFORE
<img width="490" alt="bibliography_master" src="https://user-images.githubusercontent.com/17893104/104988272-0659bc00-5a5b-11eb-86c7-bf349273eab5.png">

AFTER
<img width="422" alt="bibliography_fixed" src="https://user-images.githubusercontent.com/17893104/104988286-0e196080-5a5b-11eb-834f-f61244e2174d.png">
