### PR TITLE
add information for jyperk caltype to task_gencal.rst.

### DIFF
--- a/docs/tasks/task_gencal.rst
+++ b/docs/tasks/task_gencal.rst
@@ -54,6 +54,8 @@ Description
       subparameter
    -  'antpos' = For VLA datasets, automatic lookup of antenna
       position corrections if *antenna=''*
+   - 'jyperk' = Jy/K factors via Jy/K database Web API if infile=''
+      (ALMA only)
       
    For the VLA, *caltype='gc'* will do auto-lookup the gain curve information.
    For VLBI, gain curve information will be taken from MS.GAIN_CURVE when present
@@ -144,7 +146,13 @@ Description
       according to the observing frequencies. These caltypes are currently
       only supported for VLA (including pre-upgrade VLA) and VLBI processing.
       (Appropriate factors for ALMA are TBD.)
-   
+   -  'jyperk'  For ALMA Total Power (Single Dish), the task without
+      'infile' sub-parameter queries Jy/K DB
+      (https://asa.alma.cl/science/jy-kelvins) via internet to obtain
+      factors and generate a caltable. Or factors are taken from a 
+      file in the local storage specified by the 'infile' sub-parameter
+      to generate a caltable.
+
 
 .. _Examples:
 


### PR DESCRIPTION
The documentation for gencal task has been updated to reflect the new caltype='jyperk' developed in gencal.