### PR TITLE
Update simutil import syntax

### DIFF
--- a/docs/notebooks/simulation.ipynb
+++ b/docs/notebooks/simulation.ipynb
@@ -5,10 +5,21 @@
     "colab": {
       "name": "simulation.ipynb",
       "provenance": [],
-      "toc_visible": true
+      "toc_visible": true,
+      "include_colab_link": true
     }
   },
   "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/casangi/casadocs/blob/simutil-import/docs/notebooks/simulation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -130,13 +141,12 @@
         "**simutil** contains numerous utility methods which can assist users in generic ephemeris and geodesy calculations to aid in performing simulations and other activities in CASA, as well as some methods used internally by **simobserve** and **simanalyze**. Several of these tasks directly call the **simulator** tool in an attempt to lessen the amount of scripting required and to make it easier for the user. It is used by import and instantiation, similarly to testhelper and recipes:\n",
         "\n",
         "```\n",
-        "from simutil import simutil\n",
-        "\n",
-        "u=simutil()\n",
+        "from casatasks.private import simutil\n",
+        "mysu = simutil.simutil()\n",
         "```\n",
         "\n",
         "```\n",
-        "help u.readantenna\n",
+        "help(mysu.readantenna)\n",
         "```\n",
         "\n",
         "Antenna configuration files are important for several tasks in **simutil** and other simulator tools. Below is an example of a properly formatted configuration file.\n",
@@ -155,7 +165,8 @@
         "The observatory, COFA (center of array), coordsys (coordinate system), x, y, z, diam (diameter) and name will be interpreted as header keys or value pairs if they contain \\\"=\\\" and begin with \\#, and as comments otherwise. Other possible header keys are: zone, datum, or hemisphere. If no sixth column is provided, antenna names will default to station names. If no fifth column is provided, station names will default to A0x where x is the zero-indexed row number. To find the observatory name, one can check the known observatories list by using the **measures** tool command **me.obslist**. If an unknown observatory is specified, then one either must use absolute positions (coordsys, XYZ \\[Cartesian coordinates\\], UTM \\[Universal Transverse Mercator\\]), or specify COFA (longitude and latitude). coordsys can be XYZ (Earth-centered), UTM (easting, northing, and altitude), or LOC (xoffset, yoffset, and height). Files for many observatories can be found in the directory returned by the following command:\n",
         "\n",
         "```\n",
-        "casa.values()[0]['data']+\"/alma/simmos\"\n",
+        "import os, casatools\n",
+        "os.listdir(casatools.casadata.datapath+\"/alma/simmos/\")\n",
         "```\n",
         "\n",
         "\n"

--- a/docs/notebooks/simulation.ipynb
+++ b/docs/notebooks/simulation.ipynb
@@ -165,8 +165,7 @@
         "The observatory, COFA (center of array), coordsys (coordinate system), x, y, z, diam (diameter) and name will be interpreted as header keys or value pairs if they contain \\\"=\\\" and begin with \\#, and as comments otherwise. Other possible header keys are: zone, datum, or hemisphere. If no sixth column is provided, antenna names will default to station names. If no fifth column is provided, station names will default to A0x where x is the zero-indexed row number. To find the observatory name, one can check the known observatories list by using the **measures** tool command **me.obslist**. If an unknown observatory is specified, then one either must use absolute positions (coordsys, XYZ \\[Cartesian coordinates\\], UTM \\[Universal Transverse Mercator\\]), or specify COFA (longitude and latitude). coordsys can be XYZ (Earth-centered), UTM (easting, northing, and altitude), or LOC (xoffset, yoffset, and height). Files for many observatories can be found in the directory returned by the following command:\n",
         "\n",
         "```\n",
-        "import os, casatools\n",
-        "os.listdir(casatools.casadata.datapath+\"/alma/simmos/\")\n",
+        "casatools.casadata.datapath+\"/alma/simmos/\"\n",
         "```\n",
         "\n",
         "\n"


### PR DESCRIPTION
The basic usage instructions given for importing simutil need to match the behavior at the command prompt.

Also note that `casa.values` is no longer available so the standard library module `os` is used to get the same display of available configuration files as was previously achieved with a custom construction.