### PR TITLE
Update task_setjy.rst

### DIFF
--- a/docs/tasks/task_setjy.rst
+++ b/docs/tasks/task_setjy.rst
@@ -431,7 +431,7 @@ Examples
       scalebychan         =       True        #  scale the flux density on a per channel basis or else on a per spw basis
       standard            = 'Perley-Butler 2017' #  Flux density standard
            model          =         ''        #  File location for field model
-           listmodels     =      False        #  List the available modimages for VLA calibrators or Tb models for Solar System objects
+           listmodels     =      False        #  List the available models for VLA calibrators or Tb models for Solar System objects
            interpolation  =  'nearest'        #  method to be used to interpolate in time
       usescratch          =      False        #  Will create if necessary and use the MODEL_DATA
    
@@ -454,7 +454,7 @@ Examples
    
    ::
    
-      setjy(vis='ngc7538_XBAND.ms', field='0', modimage='3C48_X.im')
+      setjy(vis='ngc7538_XBAND.ms', field='0', model='3C48_X.im')
    
    Note that if there is no 3C48_X.im in the current directory, setjy
    looks for it in the default model data image directory.
@@ -479,8 +479,8 @@ Examples
    
    ::
    
-      No candidate modimages matching '*.im\* \*.mod*' found in .
-      Candidate modimages (*) in
+      No candidate models matching '*.im\* \*.mod*' found in .
+      Candidate models (*) in
       /users/ttsutsum/casabuilds/data/nrao/VLA/CalModels:
       3C138_A.im 3C138_L.im 3C138_U.im 3C147_C.im 3C147_Q.im
       3C147_X.im 3C286_K.im 3C286_S.im 3C48_A.im  3C48_L.im


### PR DESCRIPTION
This is an update for the documentation for CAS-13779 (the obsolete sub-parameter removal).  In the setjy section. all the references to modimage was changed to model.