### PR TITLE
Add subsection for developer builds

### DIFF
--- a/docs/notebooks/introduction.ipynb
+++ b/docs/notebooks/introduction.ipynb
@@ -898,6 +898,17 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "V7DACxTPmEvb"
+      },
+      "source": [
+        "### Developer builds \n",
+        "\n",
+        "The above instructions are appropiate for most CASA users. However, if you want to build CASA yourself you can use the developer build instructions found in the CASA git repository [CASA readme.md](https://open-bitbucket.nrao.edu/projects/CASA/repos/casa6/browse/readme.md)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "source": [
         "### Installation Tests\n",
         "\n",


### PR DESCRIPTION
This MR adds a paragraph pointing to the CASA repository if a developer build is required.
This was a left over from https://open-jira.nrao.edu/browse/CAS-14162.

@vsuorant : maybe you want to have a cursory look at this.

@jmarvil : thanks for rescuing this branch, I lost track of it!