### PR TITLE
Fixed a left over reference to CAS-14576 that was merged.

### DIFF
--- a/docs/notebooks/external-data.ipynb
+++ b/docs/notebooks/external-data.ipynb
@@ -40,7 +40,7 @@
         "\n",
         "[//]: # \"Markdown Comment: This figure is maintained as a google drawing in the Infrastructure directory of the CASA google drive: casaconfig_system figure.\"\n",
         "\n",
-        "![casaconfigsystem](https://github.com/casangi/casadocs/blob/CAS-14576/docs/notebooks/media/casaconfig_system.png?raw=1)\n",
+        "![casaconfigsystem](https://github.com/casangi/casadocs/blob/master/docs/notebooks/media/casaconfig_system.png?raw=1)\n",
         "\n",
         "\n",
         "The following sections illustrate how to manually manipulate data contents. By default, CASA will generally handle this automatically after the initial installation unless the user overrides the settings with their own ~/casa/config.py file.\n",


### PR DESCRIPTION
forgot to revert the link for casaconfig_system.png from the branch to master, fixed now.