### PR TITLE
Update task_fringefit.rst

### DIFF
--- a/docs/tasks/task_fringefit.rst
+++ b/docs/tasks/task_fringefit.rst
@@ -199,22 +199,6 @@ Description
    coherence of the spectral windows by applying a 'manual phase cal' 
    solution from a strong source scan; electronic stability among spws 
    is also required.
-
-   .. rubric:: Correlation combination: *corrcomb*
-
-   To improve fringefit sensitivity when the observed correlations are 
-   coherent, *corrcomb='all'* may be specified to trigger a single 
-   solution shared by both polarizations. If the residual calibration 
-   phase is dominated by unpolarized atmospheric path-length changes, 
-   this is a viable approach (cf *gaintype='T'* in **gaincal**). The default, 
-   *corrcomb='none'*, triggers separate solutions for each polarization. 
-   Polarization coherence should be ensured by (a) applying a 'manual 
-   phase cal' solution from a strong source scan, and (b) using 
-   *parang=True* (for VLBI arrays with time-dependent differential 
-   parallactic angle variation among antennas) in **fringefit** and all 
-   prior calibration solves. NB: If *corrdepflags=True*, *corrcomb='all'* 
-   will currently flag data to any antennas which have only one 
-   polarization available.
    
    .. rubric:: Select active parameters for least square solver: *paramactive*
    


### PR DESCRIPTION
It looks like when CAS-14195 was merged, the updated description of parameter `corrcomb` was added to the fringefit task docs but the old description (referencing the deprecated setting `'all'`) wasn't updated or removed. I found this when fixing a benchmark test which was failing due to its use of the old parameter (https://github.com/casangi/casabench/commit/42f48e382d35dee37e70f60b7d9094d6444a5c2a).